### PR TITLE
optimize, node usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@
  */
 
 
-;(this.String || this).naturalCompare = function(a, b) {
+var naturalCompare = function(a, b) {
 	var i, codeA
 	, codeB = 1
 	, posA = 0
@@ -50,5 +50,8 @@
 	return 0
 }
 
-
-
+try {
+	module.exports = naturalCompare;
+} catch (e) {
+	String.naturalCompare = naturalCompare;
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,5 +1,5 @@
 
-var naturalCompare = require("../").naturalCompare
+var naturalCompare = require("../")
 
 var arr1 = [1.001, 1.002, 1.010, 1.02, 1.1, 1.3]
 , arr2 = [-1.001, -1.002, -1.010, -1.02, -1.1, -1.3]
@@ -72,4 +72,3 @@ describe ("naturalCompare").
 		}).
 		equal(["a", "ä", "B", "Š", "X", "A", "õ", "z", "1", "2", "9", "10"].sort(naturalCompare).join(""), "12910ABŠXazõä").
 done()
-


### PR DESCRIPTION
the previous commit that attempted to allow node usage had a few issues https://github.com/litejs/natural-compare-lite/commit/21c4860596beb71e05c80e2be465ec6dc76be830
- it wasn't node like usage from within node, like @ben-eb mentioned
- it still modified the `String` function

this method doesn't remove the old api, and doesn't modify `String` when used in node